### PR TITLE
Handle s3 event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,12 @@ declare module "@luxuryescapes/lib-events" {
     checksum: string;
   };
 
-  function poll(processMessage: Function): Promise<void>;
+  type PollingOptions = {
+    maxNumberOfMessages: number;
+    maxIterations: number;
+  }
+
+  function poll(processMessage: Function, options: PollingOptions): Promise<void>;
 
   function mapAttributes(data: SNSMessage): Message;
 

--- a/index.js
+++ b/index.js
@@ -187,7 +187,11 @@ function deleteMessage(message) {
 }
 
 function getAttributes(body) {
-  return mapAttributes(JSON.parse(body));
+  const bodyJson = JSON.parse(body);
+  // handle s3 upload event
+  if (bodyJson.Records) return bodyJson.Records;
+
+  return mapAttributes(bodyJson);
 }
 
 function mapAttributes(data) {


### PR DESCRIPTION
Story:

In `fn-search` we want to listen to s3 upload events of expedia property updates, every time a file is uploaded in s3, an event will be pushing into sqs, then it will be processed in `fn-search` jobs.
