### PR TITLE
ignore message type that we don't want

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,8 +190,13 @@ function getAttributes(body) {
   const bodyJson = JSON.parse(body);
   // handle s3 upload event
   if (bodyJson.Records) return bodyJson.Records;
+  else if (bodyJson.MessageAttributes) {
+    // handle sns message
+    return mapAttributes(bodyJson);
+  }
 
-  return mapAttributes(bodyJson);
+  // do nothing if the message type it not what we need
+  return {};
 }
 
 function mapAttributes(data) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/jest && yarn run lint",


### PR DESCRIPTION
When setup SQS events in S3 bucket, a testing event will be pushed into queue, this PR is to ignore the unwanted messages

The test event body:
```
{
  Service: 'Amazon S3',
  Event: 's3:TestEvent',
  Time: '2020-09-15T01:38:05.620Z',
  Bucket: 'le-chris-nguyen-dev',
  RequestId: '6995D9A7AD11B7F6',
  HostId: 'rofW5HVDvoyVhbo4CZHGz23qtOF9hXFoeqDDgXm3VqccJ5s0RuGuYcHl9wFV6bZ0cDzoy9CTiBw='
}
```