### PR TITLE
Add json field

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,8 @@ declare module "@luxuryescapes/lib-events" {
   const PROPERTY_UPDATE: string;
   const PROPERTY_DELETE: string;
 
+  const ROOM_AVAILABILITY_UPDATE: string;
+
   const HOTEL_RESERVATION_SITEMINDER_ERROR: string;
   const HOTEL_RESERVATION_TRAVELCLICK_ERROR: string;
 

--- a/index.js
+++ b/index.js
@@ -134,9 +134,9 @@ function dispatch({ type, uri, id, checksum, source, message, json }) {
     throw new InvalidEventMessageError("event message is required");
   }
 
-  let JsonStr;
+  let jsonStr;
   try {
-    JsonStr = JSON.stringify(json);
+    jsonStr = JSON.stringify(json);
   } catch (e) {
     throw new InvalidEventJsonError("event json is invalid");
   }
@@ -156,7 +156,7 @@ function dispatch({ type, uri, id, checksum, source, message, json }) {
     },
     json: {
       DataType: "String",
-      StringValue: JsonStr
+      StringValue: jsonStr
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "1.0.30",
+  "version": "1.0.31",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/jest && yarn run lint",


### PR DESCRIPTION
* return only the first element of `Records` for S3 events
* add `json` field, when publish message it will be stringified, then parsed back to json when consume the message
* add limitation of maximum 256KB message so we can catch the error if `json` filed is too large