### PR TITLE
add type and id in json field to avoid empty json string

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function dispatch({ type, uri, id, checksum, source, message, json }) {
 
   let jsonStr;
   try {
-    jsonStr = JSON.stringify(json);
+    jsonStr = JSON.stringify(Object.assign({ type, id }, json));
   } catch (e) {
     throw new InvalidEventJsonError("event json is invalid");
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/jest && yarn run lint",


### PR DESCRIPTION
`json` should be used as an optional field, but turns out aws sdk doesn't accept empty string, so add `type` and `id` in json as place holder.

Error:
ParameterValueInvalid: The message attribute 'json' must contain non-empty message attribute value for message attribute type 'String'.