### PR TITLE
Use base58 to encode json

### DIFF
--- a/base58.js
+++ b/base58.js
@@ -1,0 +1,21 @@
+// SNS -> SQS subscription could not filter message
+// if the message contains a stringified JSON
+// use base58 to encode str instead
+// https://stackoverflow.com/questions/59853890/sns-subscription-filter-policies-do-not-seem-to-work-when-a-binary-message-attri
+
+function encodeJson(json) {
+  const jsonStr = JSON.stringify(json);
+  const buff = Buffer.from(jsonStr);
+  return buff.toString("base64");
+}
+
+function decodeJson(base64) {
+  const buff = Buffer.from(base64, "base64");
+  const jsonStr = buff.toString(buff);
+  return JSON.parse(jsonStr);
+}
+
+module.exports = {
+  encodeJson,
+  decodeJson
+};

--- a/base64.js
+++ b/base64.js
@@ -11,7 +11,7 @@ function encodeJson(json) {
 
 function decodeJson(base64) {
   const buff = Buffer.from(base64, "base64");
-  const jsonStr = buff.toString(buff);
+  const jsonStr = buff.toString("utf-8");
   return JSON.parse(jsonStr);
 }
 

--- a/base64.js
+++ b/base64.js
@@ -1,6 +1,6 @@
 // SNS -> SQS subscription could not filter message
 // if the message contains a stringified JSON
-// use base58 to encode str instead
+// use base64 to encode str instead
 // https://stackoverflow.com/questions/59853890/sns-subscription-filter-policies-do-not-seem-to-work-when-a-binary-message-attri
 
 function encodeJson(json) {

--- a/index.js
+++ b/index.js
@@ -135,13 +135,6 @@ function dispatch({ type, uri, id, checksum, source, message, json }) {
     throw new InvalidEventMessageError("event message is required");
   }
 
-  let jsonBase64;
-  try {
-    jsonBase64 = encodeJson(json);
-  } catch (e) {
-    throw new InvalidEventJsonError("event json is invalid");
-  }
-
   const messageAttributes = {
     type: {
       DataType: "String",
@@ -172,10 +165,14 @@ function dispatch({ type, uri, id, checksum, source, message, json }) {
   }
 
   if (json) {
-    messageAttributes.json = {
-      DataType: "String",
-      StringValue: jsonBase64
-    };
+    try {
+      messageAttributes.json = {
+        DataType: "String",
+        StringValue: encodeJson(json)
+      };
+    } catch (e) {
+      throw new InvalidEventJsonError("event json is invalid");
+    }
   }
 
   const eventParams = {

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const AWS = require("aws-sdk");
-const { encodeJson, decodeJson } = require("./base58");
+const { encodeJson, decodeJson } = require("./base64");
 
 const sns = new AWS.SNS({
   apiVersion: "2010-03-31",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/jest && yarn run lint",


### PR DESCRIPTION
SNS -> SQS subscription could not filter message if the message contains a stringified JSON, so use base58 to encode str instead

https://stackoverflow.com/questions/59853890/sns-subscription-filter-policies-do-not-seem-to-work-when-a-binary-message-attri