### PR TITLE
[ENGX-69] - Allow for multiple publishers and consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ const { createPublisher } = require('lib-events');
 const publisher = createPublisher({
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  region: 'ap-southeast-2a',
+  region: 'ap-southeast-2',
   topic: 'my-sns-topic',
   apiHost: 'https://our-api.com'
 })
@@ -44,8 +44,8 @@ const { createConsumer } = require('lib-events');
 const consumer = createConsumer({
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  region: 'ap-southeast-2a',
-  sqsUrl: 'https://sqs.ap-southeast-2.amazonaws.com/1234/my-sqs-name'
+  region: 'ap-southeast-2',
+  queueUrl: 'https://sqs.ap-southeast-2.amazonaws.com/1234/my-sqs-name'
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,12 +2,30 @@
 
 SNS messages and SQS queues helper lib
 
-## Dispatch
+## Publisher
+
+A small wrapper around SNS
 
 ```js
-const { dispatch, ORDER_CREATED } = require('lib-events');
+const { createPublisher } = require('lib-events');
 
-dispatch({
+const publisher = createPublisher({
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  region: 'ap-southeast-2a',
+  topic: 'my-sns-topic',
+  apiHost: 'https://our-api.com'
+})
+```
+
+### Dispatch
+
+```js
+const { createPublisher, ORDER_CREATED } = require('lib-events');
+
+const publisher = createPublisher({ ... })
+
+publisher.dispatch({
   type: ORDER_CREATED,
   uri: `/api/orders/${order.id_orders}`,
   checksum: order.checksum,
@@ -16,10 +34,27 @@ dispatch({
 })
 ```
 
-## Poll
+## Consumers
+
+A small wrapper around SQS
 
 ```js
-const { poll, ORDER_CREATED } = require('lib-events');
+const { createConsumer } = require('lib-events');
+
+const consumer = createConsumer({
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  region: 'ap-southeast-2a',
+  sqsUrl: 'https://sqs.ap-southeast-2.amazonaws.com/1234/my-sqs-name'
+})
+```
+
+### Poll
+
+```js
+const { createConsumer, ORDER_CREATED } = require('lib-events');
+
+const consumer = createConsumer({ ... })
 
 async function processMessage({ type, source, id, checksum }, ack) {
   if (type === ORDER_CREATED) {
@@ -30,7 +65,7 @@ async function processMessage({ type, source, id, checksum }, ack) {
 }
 
 exports.process = async function () {
-  await poll(processMessage, {
+  await consumer.poll(processMessage, {
     maxNumberOfMessages: 10,
     maxIterations: 10
   });

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,9 +4,11 @@ declare module "@luxuryescapes/lib-events" {
   type Message = {
     type: string;
     source: string;
-    id: string;
-    uri: string;
+    id?: string;
+    uri?: string;
     checksum: string;
+    message: string;
+    json?: string
   };
 
   type PollingOptions = {
@@ -14,9 +16,33 @@ declare module "@luxuryescapes/lib-events" {
     maxIterations: number;
   }
 
-  function poll(processMessage: Function, options: PollingOptions): Promise<void>;
+  interface ConsumerParams {
+    accessKeyId: string;
+    secretAccessKey: string;
+    region: string;
+    queueUrl: string;
+  }
 
-  function mapAttributes(data: SNSMessage): Message;
+  interface Consumer {
+    poll: (processMessage: Function, options: PollingOptions) => Promise<void>;
+    mapAttributes: (data: SNSMessage) => Message;
+  }
+
+  function createConsumer(params: ConsumerParams): Consumer;
+
+  interface PublisherParams {
+    accessKeyId: string;
+    secretAccessKey: string;
+    region: string;
+    topic: string;
+    apiHost: string;
+  }
+
+  interface Publisher {
+    dispatch: (message: Message) => Promise<void>
+  }
+
+  function createPublisher(params: PublisherParams): Publisher
 
   const ORDER_PENDING: string;
   const ORDER_COMPLETED: string;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,6 @@
 const AWS = require("aws-sdk");
 const { encodeJson, decodeJson } = require("./base64");
 
-const sns = new AWS.SNS({
-  apiVersion: "2010-03-31",
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  region: process.env.AWS_SNS_REGION
-});
-
 // Amazon SNS currently allows a maximum size of 256 KB for published messages.
 const MAX_EVENT_MESSAGE_SIZE = 256 * 1024;
 
@@ -127,207 +120,232 @@ class InvalidEventSizeError extends Error {
   }
 }
 
-function dispatch({ type, uri, id, checksum, source, message, json }) {
-  if (!types[type]) {
-    throw new InvalidEventTypeError(`invalid event type '${type}'`);
-  }
-
-  if (isNaN(checksum)) {
-    throw new InvalidEventChecksumError("checksum is not a number");
-  }
-
-  if (!source) {
-    throw new InvalidEventSourceError("event source is required");
-  }
-
-  if (!message) {
-    throw new InvalidEventMessageError("event message is required");
-  }
-
-  const messageAttributes = {
-    type: {
-      DataType: "String",
-      StringValue: type
-    },
-    checksum: {
-      DataType: "Number",
-      StringValue: checksum.toString()
-    },
-    source: {
-      DataType: "String",
-      StringValue: source
+function createPublisher({
+  accessKeyId,
+  secretAccessKey,
+  region,
+  topic,
+  apiHost
+}) {
+  const sns = new AWS.SNS({
+    apiVersion: "2010-03-31",
+    accessKeyId,
+    secretAccessKey,
+    region
+  });
+  function dispatch({ type, uri, id, checksum, source, message, json }) {
+    if (!types[type]) {
+      throw new InvalidEventTypeError(`invalid event type '${type}'`);
     }
-  };
 
-  if (uri) {
-    messageAttributes.uri = {
-      DataType: "String",
-      StringValue: `${process.env.API_HOST}${uri}`
-    };
-  }
+    if (isNaN(checksum)) {
+      throw new InvalidEventChecksumError("checksum is not a number");
+    }
 
-  if (id) {
-    messageAttributes.id = {
-      DataType: "String",
-      StringValue: id
-    };
-  }
+    if (!source) {
+      throw new InvalidEventSourceError("event source is required");
+    }
 
-  if (json) {
-    try {
-      messageAttributes.json = {
+    if (!message) {
+      throw new InvalidEventMessageError("event message is required");
+    }
+
+    const messageAttributes = {
+      type: {
         DataType: "String",
-        StringValue: encodeJson(json)
+        StringValue: type
+      },
+      checksum: {
+        DataType: "Number",
+        StringValue: checksum.toString()
+      },
+      source: {
+        DataType: "String",
+        StringValue: source
+      }
+    };
+
+    if (uri) {
+      messageAttributes.uri = {
+        DataType: "String",
+        StringValue: `${apiHost}${uri}`
       };
-    } catch (e) {
-      throw new InvalidEventJsonError("event json is invalid");
     }
-  }
 
-  const eventParams = {
-    MessageAttributes: messageAttributes,
-    TopicArn: process.env.AWS_SNS_TOPIC_ARN,
-    Message: message
-  };
+    if (id) {
+      messageAttributes.id = {
+        DataType: "String",
+        StringValue: id
+      };
+    }
 
-  if (
-    Buffer.byteLength(JSON.stringify(eventParams), "utf8") >
-    MAX_EVENT_MESSAGE_SIZE
-  ) {
-    throw new InvalidEventSizeError("json message exceeded limit of 256KB");
-  }
-
-  if (process.env.IGNORE_EVENTS == "true") {
-    return Promise.resolve();
-  }
-
-  return sns.publish(eventParams).promise();
-}
-
-const sqs = new AWS.SQS({
-  apiVersion: "2012-11-05",
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  region: process.env.AWS_SQS_REGION
-});
-
-const queueUrl = process.env.AWS_SQS_QUERY_URL;
-
-function deleteMessage(message) {
-  return function ack() {
-    return new Promise((accept, reject) => {
-      sqs.deleteMessage(
-        {
-          QueueUrl: queueUrl,
-          ReceiptHandle: message.ReceiptHandle
-        },
-        (err, response) => {
-          if (err) {
-            return reject(err);
-          }
-          return accept({
-            response,
-            message
-          });
-        }
-      );
-    });
-  };
-}
-
-function getAttributes(body) {
-  const bodyJson = JSON.parse(body);
-  // handle s3 upload event
-  // currently we can only one record per s3 event
-  // https://stackoverflow.com/questions/40765699/how-many-records-can-be-in-s3-put-event-lambda-trigger/40767563#40767563
-  if (bodyJson.Records) return bodyJson.Records[0];
-  else if (bodyJson.MessageAttributes) {
-    // handle sns message
-    return mapAttributes(bodyJson);
-  }
-
-  // do nothing if the message type it not what we need
-  return {};
-}
-
-function mapAttributes(data) {
-  const attributeReducer = (accumulator, currentValue) => {
-    if (data.MessageAttributes[currentValue]) {
-      if (currentValue === "json") {
-        try {
-          accumulator[currentValue] = decodeJson(
-            data.MessageAttributes[currentValue].Value
-          );
-        } catch (e) {
-          console.log(e);
-        }
-      } else {
-        accumulator[currentValue] = data.MessageAttributes[currentValue].Value;
+    if (json) {
+      try {
+        messageAttributes.json = {
+          DataType: "String",
+          StringValue: encodeJson(json)
+        };
+      } catch (e) {
+        throw new InvalidEventJsonError("event json is invalid");
       }
     }
-    return accumulator;
-  };
 
-  const attributeList = ["type", "uri", "id", "checksum", "source", "json"];
+    const eventParams = {
+      MessageAttributes: messageAttributes,
+      TopicArn: topic,
+      Message: message
+    };
 
-  return attributeList.reduce(attributeReducer, {});
-}
+    if (
+      Buffer.byteLength(JSON.stringify(eventParams), "utf8") >
+      MAX_EVENT_MESSAGE_SIZE
+    ) {
+      throw new InvalidEventSizeError("json message exceeded limit of 256KB");
+    }
 
-function receiveMessages(processMessage, data) {
-  if (!data.Messages || data.Messages.length === 0) {
-    return [];
-  }
-  return data.Messages.map(message => {
-    return processMessage(getAttributes(message.Body), deleteMessage(message));
-  });
-}
-
-function wait(processMessage, receiveMessageParams) {
-  return new Promise((accept, reject) => {
-    sqs.receiveMessage(receiveMessageParams, (err, data) => {
-      if (err) {
-        return reject(err);
-      }
-      Promise.all(receiveMessages(processMessage, data))
-        .then(accept)
-        .catch(reject);
-    });
-  });
-}
-
-function pollStart(processMessage, n, t, receiveMessageParams) {
-  if (t >= n) {
-    return Promise.resolve();
-  }
-  return wait(processMessage, receiveMessageParams).then(results => {
-    if (results.length == 0) {
+    if (process.env.IGNORE_EVENTS == "true") {
       return Promise.resolve();
     }
-    return poll(processMessage, n, t + 1);
-  });
+
+    return sns.publish(eventParams).promise();
+  }
+  return {
+    dispatch
+  };
 }
 
-function poll(
-  processMessage,
-  { maxNumberOfMessages, maxIterations } = {
-    maxNumberOfMessages: 10,
-    maxIterations: 10
-  }
-) {
-  const receiveMessageParams = {
-    QueueUrl: queueUrl,
-    MaxNumberOfMessages: maxNumberOfMessages
-  };
+function createConsumer({ accessKeyId, secretAccessKey, region, queueUrl }) {
+  const sqs = new AWS.SQS({
+    apiVersion: "2012-11-05",
+    accessKeyId,
+    secretAccessKey,
+    region
+  });
 
-  return pollStart(processMessage, maxIterations, 0, receiveMessageParams);
+  function deleteMessage(message) {
+    return function ack() {
+      return new Promise((accept, reject) => {
+        sqs.deleteMessage(
+          {
+            QueueUrl: queueUrl,
+            ReceiptHandle: message.ReceiptHandle
+          },
+          (err, response) => {
+            if (err) {
+              return reject(err);
+            }
+            return accept({
+              response,
+              message
+            });
+          }
+        );
+      });
+    };
+  }
+
+  function getAttributes(body) {
+    const bodyJson = JSON.parse(body);
+    // handle s3 upload event
+    // currently we can only one record per s3 event
+    // https://stackoverflow.com/questions/40765699/how-many-records-can-be-in-s3-put-event-lambda-trigger/40767563#40767563
+    if (bodyJson.Records) return bodyJson.Records[0];
+    else if (bodyJson.MessageAttributes) {
+      // handle sns message
+      return mapAttributes(bodyJson);
+    }
+
+    // do nothing if the message type it not what we need
+    return {};
+  }
+
+  function mapAttributes(data) {
+    const attributeReducer = (accumulator, currentValue) => {
+      if (data.MessageAttributes[currentValue]) {
+        if (currentValue === "json") {
+          try {
+            accumulator[currentValue] = decodeJson(
+              data.MessageAttributes[currentValue].Value
+            );
+          } catch (e) {
+            console.log(e);
+          }
+        } else {
+          accumulator[currentValue] =
+            data.MessageAttributes[currentValue].Value;
+        }
+      }
+      return accumulator;
+    };
+
+    const attributeList = ["type", "uri", "id", "checksum", "source", "json"];
+
+    return attributeList.reduce(attributeReducer, {});
+  }
+
+  function receiveMessages(processMessage, data) {
+    if (!data.Messages || data.Messages.length === 0) {
+      return [];
+    }
+    return data.Messages.map(message => {
+      return processMessage(
+        getAttributes(message.Body),
+        deleteMessage(message)
+      );
+    });
+  }
+
+  function wait(processMessage, receiveMessageParams) {
+    return new Promise((accept, reject) => {
+      sqs.receiveMessage(receiveMessageParams, (err, data) => {
+        if (err) {
+          return reject(err);
+        }
+        Promise.all(receiveMessages(processMessage, data))
+          .then(accept)
+          .catch(reject);
+      });
+    });
+  }
+
+  function pollStart(processMessage, n, t, receiveMessageParams) {
+    if (t >= n) {
+      return Promise.resolve();
+    }
+    return wait(processMessage, receiveMessageParams).then(results => {
+      if (results.length == 0) {
+        return Promise.resolve();
+      }
+      return poll(processMessage, n, t + 1);
+    });
+  }
+
+  function poll(
+    processMessage,
+    { maxNumberOfMessages, maxIterations } = {
+      maxNumberOfMessages: 10,
+      maxIterations: 10
+    }
+  ) {
+    const receiveMessageParams = {
+      QueueUrl: queueUrl,
+      MaxNumberOfMessages: maxNumberOfMessages
+    };
+
+    return pollStart(processMessage, maxIterations, 0, receiveMessageParams);
+  }
+
+  return {
+    poll,
+    getAttributes,
+    mapAttributes
+  };
 }
 
 module.exports = Object.assign(
   {
-    poll,
-    dispatch,
-    getAttributes,
-    mapAttributes,
+    createPublisher,
+    createConsumer,
     InvalidEventTypeError,
     InvalidEventChecksumError,
     InvalidEventSourceError,

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const {
-  dispatch,
-  poll,
+  createPublisher,
+  createConsumer,
   getAttributes,
   InvalidEventTypeError,
 	InvalidEventChecksumError,
@@ -11,13 +11,28 @@ const {
   ORDERS_CHECKSUM
 } = require('./index.js');
 
+const publisher = createPublisher({
+  accessKeyId: 'key',
+  secretAccessKey: 'secret',
+  region: 'ap-southeast-2',
+  topic: 'my-sns-topic',
+  apiHost: 'https://our-api.com'
+})
+
+const consumer = createConsumer({
+  accessKeyId: 'key',
+  secretAccessKey: 'secret',
+  region: 'ap-southeast-2',
+  queueUrl: 'https://sqs.ap-southeast-2.amazonaws.com/1234/my-sqs-name'
+})
+
 it('should have queue poll fun', function() {
-  expect(poll).toBeDefined()
+  expect(consumer.poll).toBeDefined()
 });
 
 it('should throw error if invalid type', function() {
   const fun = () => {
-    dispatch({
+    publisher.dispatch({
       type: 'NA',
       uri: '/api',
       checksum: 1,
@@ -33,7 +48,7 @@ it('should throw error if invalid type', function() {
 
 it('should throw error if invalid checksum', function() {
   const fun = () => {
-    dispatch({
+    publisher.dispatch({
       type: ORDER_PENDING,
       uri: '/api',
       checksum: 'x',
@@ -49,7 +64,7 @@ it('should throw error if invalid checksum', function() {
 
 it('should throw error no source', function() {
   const fun = () => {
-    dispatch({
+    publisher.dispatch({
       type: ORDER_PENDING,
       uri: '/api',
       checksum: 1,
@@ -65,7 +80,7 @@ it('should throw error no source', function() {
 
 it('should throw error no source', function() {
   const fun = () => {
-    dispatch({
+    publisher.dispatch({
       type: ORDER_PENDING,
       uri: '/api',
       checksum: 1,
@@ -96,7 +111,7 @@ it('should pluck the message attributes', function() {
     }
   });
 
-  expect(getAttributes(body)).toEqual(attributes)
+  expect(consumer.getAttributes(body)).toEqual(attributes)
 });
 
 it('should pluck the message attributes without id', function() {
@@ -116,5 +131,5 @@ it('should pluck the message attributes without id', function() {
     }
   });
 
-  expect(getAttributes(body)).toEqual(attributes)
+  expect(consumer.getAttributes(body)).toEqual(attributes)
 });

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "@luxuryescapes/lib-events",
   "version": "1.0.40",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "./node_modules/.bin/jest && yarn run lint",
     "test-watch": "./node_modules/.bin/jest --watch",
     "lint": "./node_modules/.bin/eslint index.js",
-    "lint-fix": "./node_modules/.bin/eslint --fix index.js",
+    "lint:fix": "./node_modules/.bin/eslint --fix index.js",
     "build": "echo \"no build\"",
     "prepare": "yarn run build",
     "prepublishOnly": "yarn test && yarn run lint",


### PR DESCRIPTION
**NOTE** I havn't done any code changes yet, just wanted to see if this interface looked good. Have gone for factory style rather than classes

# Problem

* can only publish to a single sns topic
* can only listen to a single sqs
* a bunch of undocumented env vars are needed to get it going

# Solution

* expose functions to create publishers and consumers
* use params rather than env vars

# Read Me 

# lib-events

SNS messages and SQS queues helper lib

## Publisher

A small wrapper around SNS

```js
const { createPublisher } = require('lib-events');

const publisher = createPublisher({
  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
  region: 'ap-southeast-2',
  topic: 'my-sns-topic',
  apiHost: 'https://our-api.com'
})
```

### Dispatch

```js
const { createPublisher, ORDER_CREATED } = require('lib-events');

const publisher = createPublisher({ ... })

publisher.dispatch({
  type: ORDER_CREATED,
  uri: `/api/orders/${order.id_orders}`,
  checksum: order.checksum,
  source: process.env.HEROKU_APP_NAME,
  message: `${user.fullname} just purchased ${order.offer.name}`
})
```

## Consumers

A small wrapper around SQS

```js
const { createConsumer } = require('lib-events');

const consumer = createConsumer({
  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
  region: 'ap-southeast-2',
  queueUrl: 'https://sqs.ap-southeast-2.amazonaws.com/1234/my-sqs-name'
})
```

### Poll

```js
const { createConsumer, ORDER_CREATED } = require('lib-events');

const consumer = createConsumer({ ... })

async function processMessage({ type, source, id, checksum }, ack) {
  if (type === ORDER_CREATED) {
    console.log(`${source} created an order!`);
  }

  await ack()
}

exports.process = async function () {
  await consumer.poll(processMessage, {
    maxNumberOfMessages: 10,
    maxIterations: 10
  });
}
```