### PR TITLE
fix(types): fix the type of checksum

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare module "@luxuryescapes/lib-events" {
     source: string;
     id?: string;
     uri?: string;
-    checksum: string;
+    checksum: number;
     message: string;
     json?: string;
     transactionId?: string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
Seems that this type has always been wrong, it should be a number not a string
I checked svc-reservation and svc-order and they are both sending numbers

There is also code [here](https://github.com/lux-group/lib-events/blob/master/index.js#L165) that checks whether it's a number before putting it on the queue