### PR TITLE
[CRUZ-67] Creates CRUISE_SYNC event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -111,4 +111,6 @@ declare module "@luxuryescapes/lib-events" {
 
   const BEDBANK_PROPERTY_FLIGHT_UPDATE: string;
   const BEDBANK_SYNC: string;
+
+  const CRUISE_SYNC: string;
 }

--- a/index.js
+++ b/index.js
@@ -69,7 +69,9 @@ const typeList = [
   "ARI_AVAILABILITY_UPDATE",
 
   "BEDBANK_PROPERTY_FLIGHT_UPDATE",
-  "BEDBANK_SYNC"
+  "BEDBANK_SYNC",
+
+  "CRUISE_SYNC"
 ];
 
 const typeReducer = (accumulator, currentValue) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "2.1.5",
+  "version": "2.1.6",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
This ADD CRUISE_SYNC event to the lib. 

This is part of the work in progress to make Cruises searchable from svc-search. It envolves: 

- cruise app pushes data to new s3 bucket
- cruise app sends a message to SNS topic that search is listening too
- search downloads the file from the new s3 bucket