### PR TITLE
[CRUZ-67] add optional sessionToken param to createPublisher

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,7 @@ declare module "@luxuryescapes/lib-events" {
   interface PublisherParams {
     accessKeyId: string;
     secretAccessKey: string;
+    sessionToken?: string;
     region: string;
     topic: string;
     apiHost: string;

--- a/index.js
+++ b/index.js
@@ -140,16 +140,24 @@ class InvalidFIFOMessageError extends Error {
 function createPublisher({
   accessKeyId,
   secretAccessKey,
+  sessionToken,
   region,
   topic,
   apiHost
 }) {
-  const sns = new AWS.SNS({
+
+  const credentials = {
     apiVersion: "2010-03-31",
     accessKeyId,
     secretAccessKey,
     region
-  });
+  };
+
+  if (sessionToken) {
+    credentials.sessionToken = sessionToken;
+  }
+
+  const sns = new AWS.SNS(credentials);
   const isFIFO = topic.endsWith(".fifo");
 
   function dispatch({

--- a/index.js
+++ b/index.js
@@ -145,7 +145,6 @@ function createPublisher({
   topic,
   apiHost
 }) {
-
   const credentials = {
     apiVersion: "2010-03-31",
     accessKeyId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
Since in [CRUZ-67] we are using ARN ROLES to get credentials and operate AWS events, we must send `sessionToken` with accessKeyId and secretAccessKey.

Note: `sessionToken` is optional, so all should be working fine without it.

[CRUZ-67]: https://aussiecommerce.atlassian.net/browse/CRUZ-67?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ