### PR TITLE
CRUZ-516: add CRUISE_UPDATE event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -121,6 +121,7 @@ declare module "@luxuryescapes/lib-events" {
   const BEDBANK_UPDATE: string;
 
   const CRUISE_SYNC: string;
+  const CRUISE_UPDATE: string;
 
   const USER_SIGN_UP: string;
 }

--- a/index.js
+++ b/index.js
@@ -78,6 +78,7 @@ const typeList = [
   "BEDBANK_UPDATE",
 
   "CRUISE_SYNC",
+  "CRUISE_UPDATE",
 
   "USER_SIGN_UP"
 ];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "2.2.4",
+  "version": "2.2.5",
   "main": "index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
This ADD CRUISE_UPDATE event to the lib.

This is part of the work in progress to make Cruises searchable from svc-search. It envolves:

- a cruise offer is curated
- cruise svc app sends a message to SNS topic that search is listening too, with CRUISE_UPDATE event
- search get's the offer from svc-cruise and add it to it's db