### PR TITLE
feat[CAR-204] add car-hire location sync event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -128,4 +128,6 @@ declare module "@luxuryescapes/lib-events" {
   const CRUISE_UPDATE: string;
 
   const USER_SIGN_UP: string;
+
+  const CAR_HIRE_LOCATION_SYNC: string;
 }

--- a/index.js
+++ b/index.js
@@ -85,6 +85,8 @@ const typeList = [
   "CRUISE_UPDATE",
 
   "USER_SIGN_UP",
+
+  "CAR_HIRE_LOCATION_SYNC",
 ];
 
 const typeReducer = (accumulator, currentValue) => {


### PR DESCRIPTION
This adds CAR_HIRE_LOCATION_SYNC event to the lib.

This is part of the work in progress to make car-hire locations searchable from svc-search. It envolves:

- svc-car-hire pushes the locations as a file to S3 and sends a message to SNS topic that svc-search is listening too, with CAR_HIRE_LOCATION_SYNC event;
- svc-search get those locations pushed to S3 and add them to it's db.