### PR TITLE
bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "LE events",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Related to this PR: https://github.com/lux-group/lib-events/pull/109

version `3.0.5` was previously deployed on npm but wasn't on source code, so previous PR publish pipeline failed

<img width="447" alt="image" src="https://github.com/lux-group/lib-events/assets/33067827/411a8451-7504-4ed3-9ccd-170899752fd6">
