### PR TITLE
[GR-2817] add brand to message type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "3.0.18",
+  "version": "3.0.19",
   "description": "LE events",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export type Message<T = unknown> = {
   json?: T;
   transactionId?: string;
   groupId?: string;
+  brand?: string;
 };
 
 interface ConsumerParams {


### PR DESCRIPTION
- According to the `svc-auth` user-sign-up handler, brand information is available in the USER_SIGN_UP event, but the Type has not been defined. See https://github.com/lux-group/svc-auth/blob/cd81b4516476cb8c21b76520eefb33432abcf342/src/messages/handlers/user-sign-up.js#L15

- This pull request adds the 'brand' attribute to the `Message` type

- brand added as an optional string instead of specifically set as 'scoopon' |'cudo | etc  to accommodate the potential for empty strings to be sent according to the code.