### PR TITLE
chore(deps): upgrade aws libs to the latest version to attempt to fix errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@luxuryescapes/lib-events",
-  "version": "3.0.23",
+  "version": "3.1.0",
   "description": "LE events",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -14,8 +14,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@aws-sdk/client-sns": "^3.32.0",
-    "@aws-sdk/client-sqs": "^3.32.0"
+    "@aws-sdk/client-sns": "^3.699.0",
+    "@aws-sdk/client-sqs": "^3.699.0"
   },
   "devDependencies": {
     "@types/jest": "28.1.6",


### PR DESCRIPTION
svc-bedbank is currently experiencing errors from @aws-sdk/client-sqs which is installed by lib-events.

The change upgrades the AWS libs to the latest version to try to fix the issue.

```
TypeError: endpointFunctions[fn] is not a function
    at callFunction (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-endpoints/dist-cjs/index.js:271:31)
    at evaluateCondition (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-endpoints/dist-cjs/index.js:280:17)
    at evaluateConditions (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-endpoints/dist-cjs/index.js:293:34)
    at evaluateTreeRule (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-endpoints/dist-cjs/index.js:412:39)
    at evaluateRules (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-endpoints/dist-cjs/index.js:433:35)
    at evaluateTreeRule (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-endpoints/dist-cjs/index.js:416:10)
    at evaluateRules (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-endpoints/dist-cjs/index.js:433:35)
    at resolveEndpoint (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/util-endpoints/dist-cjs/index.js:462:20)
    at Object.defaultEndpointResolver [as endpointProvider] (/usr/src/app/node_modules/@aws-sdk/client-sqs/dist-cjs/endpoint/endpointResolver.js:7:49)
    at getEndpointFromInstructions (/usr/src/app/node_modules/@aws-sdk/client-sqs/node_modules/@smithy/middleware-endpoint/dist-cjs/index.js:127:33)
```